### PR TITLE
Switch to udev rules for usb and pci power management

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -38,6 +38,8 @@ package() {
   install -Dm644 tmpfiles.d/powersave.conf $pkgdir/etc/tmpfiles.d/powersave.conf
   install -Dm644 rules.d/50-backlight-powersave.rules $pkgdir/etc/udev/rules.d/50-backlight-powersave.rules
   install -Dm644 rules.d/50-network-powersave.rules $pkgdir/etc/udev/rules.d/50-network-powersave.rules
+  install -Dm644 rules.d/50-pci-powersave.rules $pkgdir/etc/udev/rules.d/50-pci-powersave.rules
+  install -Dm644 rules.d/50-usb-powersave.rules $pkgdir/etc/udev/rules.d/50-usb-powersave.rules
 }
 
 # vim: ft=sh syn=sh et

--- a/rules.d/50-pci-powersave.rules
+++ b/rules.d/50-pci-powersave.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="pci", ATTR{power/control}="auto"

--- a/rules.d/50-usb-powersave.rules
+++ b/rules.d/50-usb-powersave.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="usb", ATTR{power/autosuspend}="1"
+ACTION=="add", SUBSYSTEM=="usb", ATTR{power/level}="auto"

--- a/tmpfiles.d/powersave.conf
+++ b/tmpfiles.d/powersave.conf
@@ -1,5 +1,3 @@
 # /etc/tmpfiles.d/powersave.conf - powersaving settings
 
-w /sys/bus/usb/devices/*/power/autosuspend - - - - 1
-w /sys/bus/usb/devices/*/power/level - - - - auto
 w /sys/class/scsi_host/host?/link_power_management_policy - - - - min_power

--- a/tmpfiles.d/powersave.conf
+++ b/tmpfiles.d/powersave.conf
@@ -1,6 +1,5 @@
 # /etc/tmpfiles.d/powersave.conf - powersaving settings
 
-w /sys/bus/pci/devices/*/power/control - - - - auto
 w /sys/bus/usb/devices/*/power/autosuspend - - - - 1
 w /sys/bus/usb/devices/*/power/level - - - - auto
 w /sys/class/scsi_host/host?/link_power_management_policy - - - - min_power


### PR DESCRIPTION
This avoids potential race conditions (especially with usb) and will work for hotplugged devices and hubs.
